### PR TITLE
Use raskdom in place of snabbdom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Cerebral Snabbdom
+# Cerebral View Snabbdom
 
-Cerebral Snabbdom makes Cerebral a first class citizen of components. That means you have to do a lot less wiring to build components and Snabbdom is faster than React. Read more about the JSX syntax over at [snabbdom-jsx](https://github.com/yelouafi/snabbdom-jsx), it differs from React.
+Cerebral View Snabbdom makes Cerebral a first class citizen of components. That means you have to do a lot less wiring to build components and Snabbdom is faster than React. Read more about the JSX syntax over at [snabbdom-jsx](https://github.com/yelouafi/snabbdom-jsx), it differs from React.
 
 ## Install
-`npm install cerebral-snabbdom`
+`npm install cerebral-view-snabbdom`
 
 To use JSX syntax you also need Babel with the `transform-react-jsx` package.
 
@@ -21,7 +21,7 @@ To use JSX syntax you also need Babel with the `transform-react-jsx` package.
 ## Render
 
 ```js
-import {Component, render} from 'cerebral-snabbdom';
+import {Component, render} from 'cerebral-view-snabbdom';
 import App from './App';
 import controller from './controller';
 
@@ -34,7 +34,7 @@ Note that you have to pass a callback to render the initial component, returning
 ## Component
 
 ```js
-import {Component} from 'cerebral-snabbdom';
+import {Component} from 'cerebral-view-snabbdom';
 
 export default Component(() => (
 
@@ -47,7 +47,7 @@ export default Component(() => (
 By default you have access to all the state from your state tree on the `state` property passed into each components.
 
 ```js
-import {Component} from 'cerebral-snabbdom';
+import {Component} from 'cerebral-view-snabbdom';
 
 export default Component(({state}) => (
 
@@ -59,7 +59,7 @@ export default Component(({state}) => (
 You can optionally extract specific state and customize its property name:
 
 ```js
-import {Component} from 'cerebral-snabbdom';
+import {Component} from 'cerebral-view-snabbdom';
 
 export default Component({
   title: ['title'],
@@ -81,7 +81,7 @@ In this case only *title* and *rows* are available in the component, via the *st
 
 *MyComponent.js*
 ```js
-import {Component} from 'cerebral-snabbdom';
+import {Component} from 'cerebral-view-snabbdom';
 
 export default Component(({props}) => (
 
@@ -100,7 +100,7 @@ import MyComponent from './MyComponent';
 
 *MyComponent.js*
 ```js
-import {Component} from 'cerebral-snabbdom';
+import {Component} from 'cerebral-view-snabbdom';
 
 export default Component(({state, signals}) => (
 
@@ -117,7 +117,7 @@ Modules access is primarily necessary for components related to specific modules
 
 *MyComponent.js*
 ```js
-import {Component} from 'cerebral-snabbdom';
+import {Component} from 'cerebral-view-snabbdom';
 
 export default Component(({modules}) => (
 
@@ -131,7 +131,7 @@ Any component you give a `key` will be optimized under the hood. It will shallow
 
 *MyComponent.js*
 ```js
-import {Component} from 'cerebral-snabbdom';
+import {Component} from 'cerebral-view-snabbdom';
 
 const MyComponent = Component(({props}) => (
 
@@ -145,7 +145,7 @@ The key has to be **unique**. The component will only render when *title* actual
 
 *MyComponent.js*
 ```js
-import {Component} from 'cerebral-snabbdom';
+import {Component} from 'cerebral-view-snabbdom';
 
 const MyComponent = Component({
   version: ['version']

--- a/index.js
+++ b/index.js
@@ -1,15 +1,15 @@
-var snabbdom = require('snabbdom');
+var snabbdom = require('raskdom');
 var html = require('snabbdom-jsx').html;
 
 var optimized = {};
 var activeController = null;
 
 var patch = snabbdom.init([
-  require('snabbdom/modules/class'),
-  require('snabbdom/modules/props'),
-  require('snabbdom/modules/attributes'),
-  require('snabbdom/modules/style'),
-  require('snabbdom/modules/eventlisteners'),
+  require('raskdom/modules/class'),
+  require('raskdom/modules/props'),
+  require('raskdom/modules/attributes'),
+  require('raskdom/modules/style'),
+  require('raskdom/modules/eventlisteners'),
   {
     destroy: function(vnode) {
       if (vnode.key) {

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-var snabbdom = require('raskdom');
-var html = require('snabbdom-jsx').html;
+var snabbdom = require('raskdom')
+var html = require('snabbdom-jsx').html
 
-var optimized = {};
-var activeController = null;
+var optimized = {}
+var activeController = null
 
 var patch = snabbdom.init([
   require('raskdom/modules/class'),
@@ -11,48 +11,49 @@ var patch = snabbdom.init([
   require('raskdom/modules/style'),
   require('raskdom/modules/eventlisteners'),
   {
-    destroy: function(vnode) {
+    destroy: function (vnode) {
       if (vnode.key) {
-        delete optimized[key];
+        delete optimized[vnode.key]
       }
     }
   }
-]);
+])
 
 var hasChanged = function (oldProps, oldState, newProps, newState) {
   if (
     Object.keys(oldProps).length !== Object.keys(newProps).length ||
     Object.keys(oldState).length !== Object.keys(newState).length
   ) {
-    return true;
+    return true
   }
-  for (var key in oldProps) {
+  var key
+  for (key in oldProps) {
     if (oldProps[key] !== newProps[key]) {
-      return true;
+      return true
     }
   }
-  for (var key in oldState) {
+  for (key in oldState) {
     if (oldState[key] !== newState[key]) {
-      return true;
+      return true
     }
   }
-  return false;
-};
+  return false
+}
 
-function Component() {
-  var extractsState = arguments.length === 2;
-  var statePaths = arguments[0];
-  var render = extractsState ? arguments[1] : arguments[0];
+function Component () {
+  var extractsState = arguments.length === 2
+  var statePaths = arguments[0]
+  var render = extractsState ? arguments[1] : arguments[0]
 
   return function (props, children) {
-    var newState;
+    var newState
     if (extractsState) {
-      var newState = Object.keys(statePaths).reduce(function (state, key) {
-        state[key] = activeController.get(statePaths[key]);
-        return state;
-      }, {});
+      newState = Object.keys(statePaths).reduce(function (state, key) {
+        state[key] = activeController.get(statePaths[key])
+        return state
+      }, {})
     } else {
-      newState = activeController.get();
+      newState = activeController.get()
     }
 
     if (
@@ -65,7 +66,7 @@ function Component() {
         newState
       )
     ) {
-      return optimized[props.key].vnode;
+      return optimized[props.key].vnode
     }
 
     var vnode = render({
@@ -74,38 +75,36 @@ function Component() {
       state: newState,
       signals: activeController.getSignals(),
       modules: activeController.getModules()
-    });
+    })
 
     if (props.key) {
       optimized[props.key] = {
         vnode: vnode,
         props: props,
         state: newState
-      };
-      vnode.optimize = props.optimize;
+      }
+      vnode.optimize = props.optimize
     }
 
-
-
-    return vnode;
+    return vnode
   }
 };
 
-Component.DOM = html;
+Component.DOM = html
 
-module.exports.Component = Component;
+module.exports.Component = Component
 
-module.exports.render = function render(cb, el, controller) {
-  activeController = controller;
-  activeController.getDevtools().start();
+module.exports.render = function render (cb, el, controller) {
+  activeController = controller
+  activeController.getDevtools().start()
   if (activeController.getServices().router) {
-    activeController.getServices().router.trigger();
+    activeController.getServices().router.trigger()
   }
-  var prevNode = cb();
+  var prevNode = cb()
   controller.on('change', function () {
-    var newNode = cb();
-    patch(prevNode, newNode);
-    prevNode = newNode;
-  });
-  patch(el, prevNode);
+    var newNode = cb()
+    patch(prevNode, newNode)
+    prevNode = newNode
+  })
+  patch(el, prevNode)
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cerebral/cerebral-snabbdom.git"
+    "url": "git+https://github.com/cerebral/cerebral-view-snabbdom.git"
   },
   "keywords": [
     "cerebral",
@@ -19,9 +19,9 @@
   "author": "Christian Alfoni",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/cerebral/cerebral-snabbdom/issues"
+    "url": "https://github.com/cerebral/cerebral-view-snabbdom/issues"
   },
-  "homepage": "https://github.com/cerebral/cerebral-snabbdom#readme",
+  "homepage": "https://github.com/cerebral/cerebral-view-snabbdom#readme",
   "dependencies": {
     "raskdom": "^0.3.0",
     "snabbdom-jsx": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "View package for Cerebral",
   "main": "index.js",
   "scripts": {
+    "lint": "standard | snazzy",
+    "pretest": "npm run lint",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -25,5 +27,7 @@
     "snabbdom-jsx": "^0.3.0"
   },
   "devDependencies": {
+    "snazzy": "^2.0.1",
+    "standard": "^5.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "View package for Cerebral",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
@@ -26,27 +25,5 @@
     "snabbdom-jsx": "^0.3.0"
   },
   "devDependencies": {
-    "babel-loader": "^6.2.0",
-    "babel-plugin-transform-react-jsx": "^6.3.13",
-    "babel-preset-es2015": "^6.3.13",
-    "babel-preset-stage-0": "^6.3.13",
-    "baobab": "^2.2.1",
-    "cerebral": "^0.28.0",
-    "cerebral-addons": "^0.1.3",
-    "cerebral-baobab": "^0.4.3",
-    "cerebral-router": "^0.8.0",
-    "autoprefixer": "^6.0.3",
-    "css-loader": "^0.19.0",
-    "express": "^4.13.3",
-    "extract-text-webpack-plugin": "^0.8.2",
-    "html-webpack-plugin": "^1.6.1",
-    "json-loader": "^0.5.3",
-    "postcss-loader": "^0.6.0",
-    "rimraf": "^2.4.3",
-    "stats-webpack-plugin": "^0.2.1",
-    "style-loader": "^0.12.4",
-    "webpack": "^1.12.9",
-    "webpack-dev-middleware": "^1.2.0",
-    "webpack-hot-middleware": "^2.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cerebral-view-snabbdom",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "View package for Cerebral",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/cerebral/cerebral-snabbdom#readme",
   "dependencies": {
-    "snabbdom": "^0.2.8",
+    "raskdom": "^0.3.0",
     "snabbdom-jsx": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
When(if) snabbdom becomes reliable for use with cerebral, this could be reverted.
- Remove unused dev dependencies
- Use Raskdom in place of snabbdom
- Lint with standard (standard found some errors which have also been fixed)
- Fixed the package name after rename
